### PR TITLE
[Oracle] fix switch Oracle driver failed

### DIFF
--- a/chat2db-client/src/components/ConnectionEdit/config/dataSource.ts
+++ b/chat2db-client/src/components/ConnectionEdit/config/dataSource.ts
@@ -470,16 +470,16 @@ export const dataSourceFormConfigs: IConnectionConfig[] = [
           labelTextAlign: 'right',
           selects: [
             {
-              value: 'THIN',
+              value: 'thin',
               label: 'thin',
             },
             {
-              value: 'OCI',
+              value: 'oci',
               label: 'oci',
             },
             {
 
-              value: 'OCI8',
+              value: 'oci8',
               label: 'oci8',
             },
           ],


### PR DESCRIPTION
After switching the Oracle Driver, the generated URL will default to uppercase for the Driver, resulting in the following error:

Invalid Oracle URL specified.

The correct approach should be to generate the lowercase name.

<img width="848" alt="image" src="https://github.com/chat2db/Chat2DB/assets/111486498/26174d20-42fb-4900-a55c-13c58527da71">

Fix: #1164 