### PR TITLE
Fix ClassCastException when retrieving cached chat messages

### DIFF
--- a/chat2db-server/chat2db-server-web/chat2db-server-web-api/src/main/java/ai/chat2db/server/web/api/controller/ai/ChatController.java
+++ b/chat2db-server/chat2db-server-web/chat2db-server-web-api/src/main/java/ai/chat2db/server/web/api/controller/ai/ChatController.java
@@ -269,7 +269,7 @@ public class ChatController {
 
         RestAIEventSourceListener restAIEventSourceListener = new RestAIEventSourceListener(sseEmitter);
         RestAIClient.getInstance().streamCompletions(messages, restAIEventSourceListener);
-        LocalCache.CACHE.put(uid, JSONUtil.toJsonStr(messages), LocalCache.TIMEOUT);
+        LocalCache.CACHE.put(uid, messages, LocalCache.TIMEOUT);
         return sseEmitter;
     }
 
@@ -462,7 +462,8 @@ public class ChatController {
      * @return
      */
     private List<FastChatMessage> getFastChatMessage(String uid, String prompt) {
-        List<FastChatMessage> messages = (List<FastChatMessage>)LocalCache.CACHE.get(uid);
+        Object cached = LocalCache.CACHE.get(uid);
+        List<FastChatMessage> messages = (cached instanceof List) ? (List<FastChatMessage>) cached : null;
         if (CollectionUtils.isNotEmpty(messages)) {
             if (messages.size() >= contextLength) {
                 messages = messages.subList(1, contextLength);


### PR DESCRIPTION
## Issue
Fixes #1796

When using local Ollama models, a  occurs during SQL generation because the cached chat messages are being stored as a JSON string but retrieved with an unsafe cast to .

## Root Cause
The code was converting messages to a JSON string before caching:


But then retrieving and directly casting to List without type verification:


This causes a  when the cached value is a String.

## Solution
- Store messages as the object directly instead of JSON string for type consistency
- Add defensive type checking on retrieval using  before casting
- Handle null/mismatched types gracefully

This ensures type safety and prevents crashes when the cache contains unexpected types.